### PR TITLE
show list of ip addresses with CIDR netmask for network interfaces

### DIFF
--- a/app/__metadata__.py
+++ b/app/__metadata__.py
@@ -23,6 +23,8 @@ __default_config__ = """
 [LXDUI]
 lxdui.port = 15151
 lxdui.images.remote = https://images.linuxcontainers.org
+#lxdui.lxd.remote = https://lxd.host.org:8443/
+#lxdui.lxd.sslverify = true
 lxdui.jwt.token.expiration = 1200
 lxdui.jwt.secret.key = AC8d83&21Almnis710sds
 lxdui.jwt.auth.url.rule = /api/user/login

--- a/app/api/models/LXCFileManager.py
+++ b/app/api/models/LXCFileManager.py
@@ -8,7 +8,7 @@ class LXCFileManager(LXDModule):
 
     def __init__(self, input):
         logging.info('Connecting to LXD')
-        self.client = Client()
+        super().__init__()
         self.input = input
 
     def list(self):

--- a/app/api/models/LXCNetwork.py
+++ b/app/api/models/LXCNetwork.py
@@ -14,7 +14,7 @@ class LXCNetwork(LXDModule):
 
     def __init__(self, input):
         logging.info('Connecting to LXD')
-        self.client = Client()
+        super().__init__()
         logging.debug('Setting network input to {}'.format(input))
         self.input = input
 

--- a/app/api/models/LXCProfile.py
+++ b/app/api/models/LXCProfile.py
@@ -8,7 +8,7 @@ class LXCProfile(LXDModule):
 
     def __init__(self, input):
         logging.info('Connecting to LXD')
-        self.client = Client()
+        super().__init__()
         self.input = input
 
     def info(self):

--- a/app/api/models/LXCStoragePool.py
+++ b/app/api/models/LXCStoragePool.py
@@ -8,7 +8,7 @@ class LXCStoragePool(LXDModule):
 
     def __init__(self, input):
         logging.info('Connecting to LXD')
-        self.client = Client()
+        super().__init__()
         self.input = input
 
     def info(self):

--- a/app/api/models/LXDModule.py
+++ b/app/api/models/LXDModule.py
@@ -12,8 +12,28 @@ logging = logging.getLogger(__name__)
 class LXDModule(Base):
     # Default 127.0.0.1 -> Move to Config
     def __init__(self, remoteHost='127.0.0.1'):
+
+        conf = Config()
         logging.info('Accessing PyLXD client')
-        self.client = Client()
+        try:
+            remoteHost = Config().get(meta.APP_NAME, '{}.lxd.remote'.format(meta.APP_NAME.lower()))
+            sslKey = conf.get(meta.APP_NAME, '{}.ssl.key'.format(meta.APP_NAME.lower()))
+            sslCert = conf.get(meta.APP_NAME, '{}.ssl.cert'.format(meta.APP_NAME.lower()))
+            sslVerify = conf.get(meta.APP_NAME, '{}.lxd.sslverify'.format(meta.APP_NAME.lower()))
+
+            if sslVerify.lower in ['true', '1', 't', 'y', 'yes', 'yeah', 'yup', 'certainly']:
+                sslVerify = True
+            else:
+                sslVerify = False
+
+            self.client = Client(endpoint=remoteHost,
+                cert=(sslCert, sslKey), verify=sslVerify)
+        except:
+            logging.info('using local socket')
+            self.client = Client()
+
+
+
 
     def listContainers(self):
         try:

--- a/app/ui/templates/container-details.html
+++ b/app/ui/templates/container-details.html
@@ -247,7 +247,7 @@
                                             <!--</div>-->
                                      <!--</div>-->
                             </div>
-                            <div class="col-sm-3 col-md-3 col-lg-3">
+                            <div class="col-sm-4 col-md-4 col-lg-4">
                                 <ul class="network-list">
                                     <li>
                                          Interface <span class="mg-left5"> <b>{{ key }}</b></span>
@@ -260,34 +260,27 @@
                                     </li>
                                 </ul>
                             </div>
-                            <div class="col-sm-4 col-md-4 col-lg-4">
+                            <div class="col-sm-6 col-md-6 col-lg-6">
                                 <ul class="network-list">
                                     {% if value.addresses == None %}
                                     <li>N/A</li>
                                     {% else %}
-                                         {% if value.addresses|length > 0 %}
-                                            IP Address <span class="mg-left5"><b>{{value.addresses.0.address}}</b></span>
-                                         {% endif %}
-                                    <li>
-                                        MAC Address  <span class="mg-left5">{{value.hwaddr}}</span>
-                                    </li>
-                                    <li>
-                                        {% if value.addresses|length > 0  %}
-                                            {% if value.addresses.0.netmask == "24" %}
-                                                    Netmask [/{{value.addresses.0.netmask}}] <span class="mg-left5">255.255.255.0</span>
-                                            {% else %}
-
-                                                 {% if value.addresses.0.netmask != "24" %}
-                                                        Netmask [/{{value.addresses.0.netmask}}] <span class="mg-left5">[/{{value.addresses.0.netmask}}]</span>
-                                                {% endif %}
-
-                                            {% endif %}
-                                        {% endif %}
-                                    </li>
+                                         {% for address in value.addresses %}
+                                            <li>
+                                                IP{% if address.family == 'inet' %}v4{% elif address.family == 'inet6' %}v6{% endif %} Address
+                                                <span class="mg-left5"><b>{{address.address}}/{{address.netmask}}</b></span>
+                                            </li>
+                                         {% endfor %}
+                                        <li>
+                                            MAC Address  <span class="mg-left5">{{value.hwaddr}}</span>
+                                        </li>
                                     {% endif %}
                                 </ul>
                             </div>
-                            <div class="col-sm-3 col-md-3 col-lg-3">
+                            <div class="col-sm-1 col-md-1 col-lg-1 pd0">
+                                <button class="btn btn-default pull-right deleteInterfaceBtn" onclick="App.containerDetails.deleteInterface('{{key}}')"><i class="glyphicon glyphicon-trash"></i></button>
+                            </div>
+                            <div class="col-sm-3 col-md-3 col-lg-3 col-sm-offset-5 col-md-offset-5 col-lg-offset-5">
                                 <table class="table table-bordered">
                                     <tr>
                                             <th></th>
@@ -314,9 +307,6 @@
                                             <!--<br/>-->
                                         <!--{% endfor %}-->
 
-                            </div>
-                            <div class="col-sm-1 col-md-1 col-lg-1 pd0">
-                                <button class="btn btn-default pull-right deleteInterfaceBtn" onclick="App.containerDetails.deleteInterface('{{key}}')"><i class="glyphicon glyphicon-trash"></i></button>
                             </div>
                         </div>
 

--- a/app/ui/templates/container-details.html
+++ b/app/ui/templates/container-details.html
@@ -247,7 +247,7 @@
                                             <!--</div>-->
                                      <!--</div>-->
                             </div>
-                            <div class="col-sm-4 col-md-4 col-lg-4">
+                            <div class="col-sm-2 col-md-2 col-lg-2">
                                 <ul class="network-list">
                                     <li>
                                          Interface <span class="mg-left5"> <b>{{ key }}</b></span>
@@ -260,43 +260,73 @@
                                     </li>
                                 </ul>
                             </div>
-                            <div class="col-sm-6 col-md-6 col-lg-6">
+                            <div class="col-sm-5 col-md-5 col-lg-5">
                                 <ul class="network-list">
                                     {% if value.addresses == None %}
                                     <li>N/A</li>
                                     {% else %}
+                                        <li>
+                                            MAC Address  <span class="mg-left5">{{value.hwaddr}}</span>
+                                        </li>
                                          {% for address in value.addresses %}
                                             <li>
                                                 IP{% if address.family == 'inet' %}v4{% elif address.family == 'inet6' %}v6{% endif %} Address
                                                 <span class="mg-left5"><b>{{address.address}}/{{address.netmask}}</b></span>
                                             </li>
                                          {% endfor %}
-                                        <li>
-                                            MAC Address  <span class="mg-left5">{{value.hwaddr}}</span>
-                                        </li>
                                     {% endif %}
                                 </ul>
                             </div>
-                            <div class="col-sm-1 col-md-1 col-lg-1 pd0">
-                                <button class="btn btn-default pull-right deleteInterfaceBtn" onclick="App.containerDetails.deleteInterface('{{key}}')"><i class="glyphicon glyphicon-trash"></i></button>
-                            </div>
-                            <div class="col-sm-3 col-md-3 col-lg-3 col-sm-offset-5 col-md-offset-5 col-lg-offset-5">
+                            <div class="col-sm-3 col-md-3 col-lg-3">
                                 <table class="table table-bordered">
                                     <tr>
-                                            <th></th>
                                             <th>Sent</th>
                                             <th>Received</th>
                                     </tr>
                                     <tbody>
                                          <tr>
-                                             <td>Bytes</td>
-                                            <td>{{'%0.2f'|format(container.network[key]['counters']['bytes_received']/1024)}}</td>
-                                            <td>{{'%0.2f'|format(container.network[key]['counters']['bytes_sent']/1024)}}</td>
+                                            <td>{% if container.network[key]['counters']['bytes_sent'] > 1610612736 %}
+                                                    {{'%0.2f'|format(container.network[key]['counters']['bytes_sent']/1073741824)}}&nbsp;GiB
+                                             {% elif container.network[key]['counters']['bytes_sent'] > 1572864 %}
+                                                    {{'%0.2f'|format(container.network[key]['counters']['bytes_sent']/1048576)}}&nbsp;MiB
+                                             {% elif container.network[key]['counters']['bytes_sent'] > 1536 %}
+                                                    {{'%0.2f'|format(container.network[key]['counters']['bytes_sent']/1024)}}&nbsp;kiB
+                                             {% else %}
+                                                    {{'%0.2f'|format(container.network[key]['counters']['bytes_sent'])}}&nbsp;B
+                                             {% endif %}
+                                            </td>
+                                            <td>{% if container.network[key]['counters']['bytes_received'] > 1610612736 %}
+                                                    {{'%0.2f'|format(container.network[key]['counters']['bytes_received']/1073741824)}}&nbsp;GiB
+                                             {% elif container.network[key]['counters']['bytes_received'] > 1572864 %}
+                                                    {{'%0.2f'|format(container.network[key]['counters']['bytes_received']/1048576)}}&nbsp;MiB
+                                             {% elif container.network[key]['counters']['bytes_received'] > 1536 %}
+                                                    {{'%0.2f'|format(container.network[key]['counters']['bytes_received']/1024)}}&nbsp;kiB
+                                             {% else %}
+                                                    {{'%0.2f'|format(container.network[key]['counters']['bytes_received'])}}&nbsp;B
+                                             {% endif %}
+                                            </td>
                                         </tr>
                                         <tr>
-                                             <td>Packets</td>
-                                            <td>{{container.network[key]['counters']['packets_sent']}}</td>
-                                            <td>{{container.network[key]['counters']['packets_received']}}</td>
+                                            <td>{% if container.network[key]['counters']['packets_sent'] > 1500000000 %}
+                                                    {{'%0.2f'|format(container.network[key]['counters']['packets_sent']/1500000000)}}&nbsp;Gpkts
+                                             {% elif container.network[key]['counters']['packets_sent'] > 1500000 %}
+                                                    {{'%0.2f'|format(container.network[key]['counters']['packets_sent']/1000000)}}&nbsp;Mpkts
+                                             {% elif container.network[key]['counters']['packets_sent'] > 1500 %}
+                                                    {{'%0.2f'|format(container.network[key]['counters']['packets_sent']/1000)}}&nbsp;kpkts
+                                             {% else %}
+                                                    {{'%0.2f'|format(container.network[key]['counters']['packets_sent'])}}&nbsp;pkts
+                                             {% endif %}
+                                            </td>
+                                            <td>{% if container.network[key]['counters']['packets_received'] > 1500000000 %}
+                                                    {{'%0.2f'|format(container.network[key]['counters']['packets_received']/1500000000)}}&nbsp;Gpkts
+                                             {% elif container.network[key]['counters']['packets_received'] > 1500000 %}
+                                                    {{'%0.2f'|format(container.network[key]['counters']['packets_received']/1000000)}}&nbsp;Mpkts
+                                             {% elif container.network[key]['counters']['packets_received'] > 1500 %}
+                                                    {{'%0.2f'|format(container.network[key]['counters']['packets_received']/1000)}}&nbsp;kpkts
+                                             {% else %}
+                                                    {{'%0.2f'|format(container.network[key]['counters']['packets_received'])}}&nbsp;pkts
+                                             {% endif %}
+                                            </td>
                                         </tr>
                                     </tbody>
                                 </table>
@@ -307,6 +337,9 @@
                                             <!--<br/>-->
                                         <!--{% endfor %}-->
 
+                            </div>
+                            <div class="col-sm-1 col-md-1 col-lg-1 pd0">
+                                <button class="btn btn-default pull-right deleteInterfaceBtn" onclick="App.containerDetails.deleteInterface('{{key}}')"><i class="glyphicon glyphicon-trash"></i></button>
                             </div>
                         </div>
 


### PR DESCRIPTION
The existing display did not show all available IPs for an interface. Now it differentiates between IPv4 and IPv6 and shows the netmasklen in CIDR notation. /24 was expanded to 255.255.255.0 which is wrong for IPv6 /24 addresses.
The Stats were shifted to the next row, because IPv6 addresses are normally quite long.