### PR TITLE
Fix: KeyError: 'image.os' when container hasn't 'image.os'

### DIFF
--- a/app/api/controllers/terminal.py
+++ b/app/api/controllers/terminal.py
@@ -19,10 +19,11 @@ STATIC_DIR = os.path.dirname(__file__).replace('/api/controllers','/ui/static/')
 from app.api.utils.authentication import jwt_decode_handler
 
 def findShellTypeOfContainer(container):
-    containerImage = container.info()['config']['image.os'].lower()
-    for image in mappings.OS_SHELL_MAPPINGS:
-        if image in containerImage:
-            return mappings.OS_SHELL_MAPPINGS[image]
+    containerImage = container.info()['config'].get('image.os')
+    if containerImage:
+        for image in mappings.OS_SHELL_MAPPINGS:
+            if image in containerImage.lower():
+                return mappings.OS_SHELL_MAPPINGS[image]
     return 'bash'
 
 def checkAuthentication(token):


### PR DESCRIPTION
I have an error below. Terminal wasn't opend.

```
Traceback (most recent call last):
  File "/home/kacchan822/lxdui/venv/lib/python3.6/site-packages/tornado/web.py", line 1541, in _execute
    result = method(*self.path_args, **self.path_kwargs)
  File "/home/kacchan822/lxdui/app/api/controllers/terminal.py", line 48, in get
    shellType = findShellTypeOfContainer(LXCContainer({'name': name}))
  File "/home/kacchan822/lxdui/app/api/controllers/terminal.py", line 22, in findShellTypeOfContainer
    containerImage = container.info()['config']['image.os'].lower()
KeyError: 'image.os'
```

The container was created from image created by myself, so it hasn't key `image.os`.
In some cases, containers may not have `image.os` key.