### PR TITLE
Duplicate init of the super class in LXCContainer class

### DIFF
--- a/app/api/models/LXCContainer.py
+++ b/app/api/models/LXCContainer.py
@@ -45,7 +45,6 @@ class LXCContainer(LXDModule):
         if input.get('imageAlias'):
             self.setImageAlias(input.get('imageAlias'))
 
-        super(LXCContainer, self).__init__(remoteHost=self.remoteHost)
         if input.get('autostart') != None:
             self.setBootType(input.get('autostart'))
         else:


### PR DESCRIPTION
Seems like there is a duplicate and redundant super class init call in the constructor of LXCContainer, so it can be removed.