### PR TITLE
Add an option to change the listening host of the application

### DIFF
--- a/app/__metadata__.py
+++ b/app/__metadata__.py
@@ -21,6 +21,7 @@ AUTO_LOAD_CONFIG = True
 DEFAULT_CONFIG_FORMAT = 'ini'
 __default_config__ = """
 [LXDUI]
+lxdui.host = 0.0.0.0
 lxdui.port = 15151
 lxdui.images.remote = https://images.linuxcontainers.org
 lxdui.jwt.token.expiration = 1200

--- a/app/api/controllers/terminal.py
+++ b/app/api/controllers/terminal.py
@@ -51,7 +51,7 @@ class NewTerminalHandler(tornado.web.RequestHandler):
         name, terminal = self.application.settings['term_manager'].new_named_terminal(shell_command=shell)
         self.redirect("/terminal/open/" + name+'/'+token, permanent=False)
 
-def terminal(app, port, debug=False):
+def terminal(app, host, port, debug=False):
     term_manager = NamedTermManager(shell_command=None, max_terminals=100)
     wrapped_app = WSGIContainer(app)
     handlers = [
@@ -69,5 +69,5 @@ def terminal(app, port, debug=False):
                               term_manager=term_manager,
                               debug=debug)
     http_server = HTTPServer(tornado_app)
-    http_server.listen(port, '0.0.0.0')
+    http_server.listen(port, host)
     IOLoop.instance().start()

--- a/app/api/core.py
+++ b/app/api/core.py
@@ -115,7 +115,7 @@ def stop():
         logging.info(e)
 
 
-def start(port, debug=False, uiPages=None):
+def start(host, port, debug=False, uiPages=None):
     logging.debug('Checking UI availability.')
 
     if uiPages is not None:
@@ -133,7 +133,7 @@ def start(port, debug=False, uiPages=None):
     with open(PID, 'w') as f:
         f.write(str(pid))
 
-    print("LXDUI started. Running on http://0.0.0.0:{}".format(port))
+    print("LXDUI started. Running on http://{}:{}".format(host, port))
     print("PID={}, Press CTRL+C to quit".format(pid))
-    terminal(app, port, debug)
+    terminal(app, host, port, debug)
     # app.run(debug=debug, host='0.0.0.0', port=port)

--- a/app/cli/cli.py
+++ b/app/cli/cli.py
@@ -74,14 +74,16 @@ def start(debug):
 
     # Private Functions
     def _start(debug=False):
+        host = '0.0.0.0'
         port = 5000
         try:
+            host = Config().get('LXDUI', 'lxdui.host')
             port = int(Config().get('LXDUI', 'lxdui.port'))
         except:
             print('Please initialize {} first.  e.g: {} init '.format(meta.APP_NAME, meta.APP_CLI_CMD))
             exit()
 
-        core.start(port, debug, uiPages)
+        core.start(host, port, debug, uiPages)
 
     if debug:
         _start(debug=True)
@@ -99,12 +101,13 @@ def stop():
 @lxdui.command()
 def restart():
     """Restart LXDUI"""
+    host = Config().get('LXDUI', 'lxdui.host')
     port = int(Config().get('LXDUI', 'lxdui.port'))
     click.echo('Restarting with defaults.')
     core.stop()
     click.echo('Port = {} \nDebug = False\nMode = Foreground\n'.format(port))
     time.sleep(3)
-    core.start(port, False, uiPages)
+    core.start(host, port, False, uiPages)
 
 @lxdui.command()
 def status():


### PR DESCRIPTION
This adds the `host` configuration option, which allows you to change the listening IP address of the application.
This can be useful when the hypervisor has more than one network interface, e.g. one for the Internet and one for the intranet, and LXDUI should be accessible only from the intranet, but not for the whole world.