### PR TITLE
Docker : Fix missing openssl.h and ffi.h when built on ARM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt update && apt install -y python3
 ADD . /app
 WORKDIR /app
 
-RUN apt install -y python3-pip
+RUN apt install -y python3-pip libffi-dev libssl-dev
 RUN pip3 install setuptools
 RUN python3 setup.py install
 


### PR DESCRIPTION
Hi !

I tried to build the docker image for arm architecture and the setup.py step failed.

It seems neither openssl.h neither ffi.h are present in the base image which caused compilation problem.

I added the two lib dev to build and it fixed the problem. I pushed a build [here](https://hub.docker.com/repository/docker/netpascal0123/lxdui)

Regards,
Pascal Noisette