### PR TITLE
Fix for JWT authentication login loop

### DIFF
--- a/app/ui/static/js/app.js
+++ b/app/ui/static/js/app.js
@@ -105,8 +105,10 @@ var App = App || {
         });
     },
     tokenUpdateSuccess:function(response){
+        sessionStorage.removeItem('authToken');
+        document.cookie = 'access_token_cookie' + '=; Path=/; Expires=Thu, 01 Jan 1970 00:00:01 GMT;';
         sessionStorage.setItem('authToken', response.access_token);
-        document.cookie = "access_token_cookie" + "=" + response.access_token;
+        document.cookie = "access_token_cookie" + "=" + response.access_token + ";path=/";
         App.tokenRefreshing=false;
     },
     setActiveLink: function(name) {

--- a/app/ui/static/js/login.js
+++ b/app/ui/static/js/login.js
@@ -20,6 +20,8 @@ App.login = App.login || {
         });
     },
     doLoginSuccess: function(response){
+        sessionStorage.removeItem('authToken');
+        document.cookie = 'access_token_cookie' + '=; Path=/; Expires=Thu, 01 Jan 1970 00:00:01 GMT;';
         sessionStorage.setItem('authToken', response.access_token);
         document.cookie = "access_token_cookie" + "=" + response.access_token + ";path=/";
         window.location = App.baseWEB + 'containers';


### PR DESCRIPTION
This patch fixes #334. After further testing I have found out that at times the UI would be unable to overwrite the authentication token, always using the expired JWT in the cookies. 

Clearing the cookies related to JWT prior to storing it fixes the issue.