### PR TITLE
Fix `--debug` wanting an argument

### DIFF
--- a/app/cli/cli.py
+++ b/app/cli/cli.py
@@ -62,7 +62,7 @@ def init(password):
 # @click.otion('-b', '--daemon', default=False, help='Run in background as a daemon.')
 # @click.otion('-c', '--conf', default=False, help='Config file.')
 # @click.otion('-p', '--port', default=False, help='TCP Port number.')
-@click.option('-d', '--debug', default=False, help='Run the app in debug mode')
+@click.option('-d', '--debug', is_flag=True, default=False, help='Run the app in debug mode')
 def start(debug):
     """Start LXDUI"""
 


### PR DESCRIPTION
This still doesn't seem to do anything, but at least it doesn't give a confusing error message anymore.