### PR TITLE
Use bcrypt for passwords

### DIFF
--- a/app/cli/init.py
+++ b/app/cli/init.py
@@ -52,7 +52,7 @@ class Init(object):
 
     def __init__(self, password):
         c = conf.Config()
-        self.password = auth.User.sha_password(password)
+        self.password = auth.User.bcrypt_password(password)
         self.username = c.get(self.APP, '{}.admin.user'.format(self.APP.lower()))
         self.auth_file = c.get(self.APP, '{}.auth.conf'.format(self.APP.lower()))
         self.cert_file = c.get(self.APP, '{}.ssl.cert'.format(self.APP.lower()))

--- a/app/lib/auth.py
+++ b/app/lib/auth.py
@@ -4,6 +4,7 @@ import os
 import json
 import hashlib
 import logging
+import bcrypt
 
 log = logging.getLogger(__name__)
 
@@ -65,6 +66,11 @@ class User(object):
         sha1_password = hashlib.sha1(password.encode('utf-8')).hexdigest()
         return sha1_password
 
+    @classmethod
+    def bcrypt_password(cls, password):
+        hashed_password = bcrypt.hashpw(password.encode('utf-8'), bcrypt.gensalt()).decode('utf-8')
+        return hashed_password
+
     def show(self):
         # retrieve just the user names
         counter = 0
@@ -82,8 +88,7 @@ class User(object):
                 exit()
 
         data = self.users
-        sha1_password = hashlib.sha1(password.encode('utf-8')).hexdigest()
-        data.append({'username': username, 'password': sha1_password})
+        data.append({'username': username, 'password': self.bcrypt_password(password)})
         self.save(data)
 
     def delete(self, username):
@@ -112,7 +117,7 @@ class User(object):
         if account is None:
             return err
 
-        account['password'] = self.sha_password(password)
+        account['password'] = self.bcrypt_password(password)
         self.users.remove(account)
         self.users.append(account)
         # save the new auth state when done
@@ -124,7 +129,13 @@ class User(object):
         if account is None:
             return 'Error', err
 
-        if account['password'] == self.sha_password(password):
+        if len(account['password']) == 40:
+            # Can't just `and` this in the above conditional because then incorrect SHA passwords get passed to bcrypt
+            if account['password'] == self.sha_password(password):
+                # Migrate to bcrypt
+                self.update(username, password)
+                return True, 'Authenticated'
+        elif bcrypt.checkpw(password.encode('utf-8'), account['password'].encode('utf-8')):
             return True, 'Authenticated'
-        else:
-            return False, 'Incorrect password.'
+
+        return False, 'Incorrect password.'

--- a/conf/auth.conf
+++ b/conf/auth.conf
@@ -1,6 +1,6 @@
 [
   {
-    "password": "d033e22ae348aeb5660fc2140aec35850c4da997",
+    "password": "$2b$12$PdXHe003BVqO41BmweUJRuZnembRydnLDNefORb/.vE97GtOGUw6m",
     "username": "admin"
   }
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ tornado-xstatic
 XStatic==1.0.1
 XStatic-term.js==0.0.7.0
 pyyaml==3.11
+bcrypt==3.2.0


### PR DESCRIPTION
SHA1 passwords are recognized and automatically migrated.

It would be better to automatically bcrypt the existing SHA hashes, which would improve things even for users who have not logged in since this change, but it would be more complicated to do that on startup and handle all the possible login scenarios and I didn't have time/wanted to get this patch sent quickly.

Note that this introduces a dependency on the `bcrypt` package, which uses native code. Therefore this patch is semver-major because it requires deployers to have a C/C++ build toolchain installed.

Fixes #326