### PR TITLE
removed the hard coded jwt secret key

### DIFF
--- a/app/__metadata__.py
+++ b/app/__metadata__.py
@@ -28,7 +28,6 @@ lxdui.images.remote = https://images.linuxcontainers.org
 #lxdui.lxd.sslverify = true
 #lxdui.lxd.remote.name = host
 lxdui.jwt.token.expiration = 1200
-lxdui.jwt.secret.key = AC8d83&21Almnis710sds
 lxdui.admin.user = admin
 lxdui.conf.dir = {{app_root}}/conf
 lxdui.conf.file = ${lxdui.conf.dir}/lxdui.conf

--- a/app/api/utils/authentication.py
+++ b/app/api/utils/authentication.py
@@ -6,6 +6,7 @@ from flask_jwt_extended import JWTManager
 from app.api.utils import converters
 import app.__metadata__ as meta
 import logging
+import secrets
 
 logging = logging.getLogger(__name__)
 
@@ -21,7 +22,8 @@ def authenticate(username, password):
 def initAuth(app):
     APP = meta.APP_NAME
     tokenExpiration = int(Config().get(APP, '{}.jwt.token.expiration'.format(APP.lower())))
-    secretKey = Config().get(APP, '{}.jwt.secret.key'.format(APP.lower()))
+    # create a new secretKet whenever the system is started
+    secretKey = secrets.token_urlsafe(32) 
     if (tokenExpiration == None):
         tokenExpiration = 1200
 


### PR DESCRIPTION
the hard coded jwt secret key allows an attacker to generate Authentication Tokens and assume the role of the admin without needing the password.
It was replaced with a routine to create a new jwt secret token during every startup. This leads to all previous tokens being invalidated after a restart lxdui.

Changes to be committed:
modified:   __metadata__.py
modified:   api/utils/authentication.py