### PR TITLE
Fixed bug on container update while validating

### DIFF
--- a/app/api/controllers/container.py
+++ b/app/api/controllers/container.py
@@ -56,7 +56,7 @@ def createContainer():
 @jwt_required
 def updateContainer():
     input = request.get_json(silent=True)
-    validation = doValidate(input)
+    validation = doValidate(input, LXDModule().setLimitsCPU())
     if validation:
         return response.reply(message=validation.message, status=403)
 

--- a/app/api/schemas/container_schema.py
+++ b/app/api/schemas/container_schema.py
@@ -227,7 +227,7 @@ def doValidateCloneMove(input):
     except ValidationError as e:
         return e
 
-def doValidate(input, setCPU):
+def doValidate(input, setCPU = False):
     try:
         if setCPU:
             validate(input, set_cpu_limit_schema)


### PR DESCRIPTION
While updating container validation would throw error because of missing the 'limits set' configuration parameter, also added a default value for future purposes.